### PR TITLE
fix(035): correção de bugs E2E em EnhancementsPage

### DIFF
--- a/src/pages/EnhancementsPage.vue
+++ b/src/pages/EnhancementsPage.vue
@@ -57,7 +57,7 @@
             <q-td key="tipo" :props="props">
               <q-badge
                 :color="props.row.tipo === 'positivo' ? 'positive' : 'negative'"
-                :label="props.row.tipo === 'positivo' ? 'Positivo' : 'Negativo'"
+                :label="props.row.tipo === 'positivo' ? 'positivo' : 'negativo'"
               />
             </q-td>
             <q-td key="custo" :props="props">

--- a/tests/cypress/e2e/enhancements.cy.ts
+++ b/tests/cypress/e2e/enhancements.cy.ts
@@ -112,17 +112,13 @@ describe('Página de Aprimoramentos — /aprimoramentos', () => {
     // Abre o drawer via botão de menu
     cy.get('.erebus-topbar button').first().click()
 
-    // Clica no link de APRIMORAMENTOS se existir
-    cy.get('.erebus-drawer').then(($drawer) => {
-      if ($drawer.text().includes('APRIMORAMENTOS')) {
-        cy.get('.erebus-drawer').contains('APRIMORAMENTOS').click({ force: true })
-        cy.url().should('include', '/#/aprimoramentos')
-        cy.wait('@getEnhancementsFromHome')
-        cy.get('[data-testid="enhancements-container"]').should('be.visible')
-      } else {
-        cy.log('Link APRIMORAMENTOS não encontrado no drawer — ajuste necessário')
-      }
-    })
+    // Aguarda e valida que o drawer está visível
+    cy.get('.erebus-drawer').should('be.visible')
+    // Clica no link de APRIMORAMENTOS
+    cy.get('[data-testid="nav-enhancements"]').should('be.visible').click()
+    cy.url().should('include', '/#/aprimoramentos')
+    cy.wait('@getEnhancementsFromHome')
+    cy.get('[data-testid="enhancements-container"]').should('be.visible')
   })
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Bug 1 (E2E-EN-04): Alterar q-badge label de 'Positivo'/'Negativo' para 'positivo'/'negativo' (minúsculas).

Bug 2 (E2E-EN-07): Substituir lógica if/else não-assertiva do teste E2E-EN-07 por assertions explícitas com espera pelo drawer visível e uso de data-testid='nav-enhancements'.

- EnhancementsPage.vue: line 60 — label do badge em lowercase
- enhancements.cy.ts: lines 115-125 — substituir padrão if/else por assertions assertivas